### PR TITLE
Set measurement to "Non-Image" if no pixel data present

### DIFF
--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -235,6 +235,9 @@ def dicom_classify(zip_file_path, outbase, timezone):
         metadata['acquisition']['measurement'] = measurement_from_label.infer_measurement(dcm.get('SeriesDescription'))
     else:
         metadata['acquisition']['measurement'] = 'unknown'
+    # If no pixel data present, make measurement "Non-Image"
+    if not hasattr(dcm, 'PixelData'):
+        metadata['acquisition']['measurement'] = 'Non-Image'
     if acquisition_timestamp:
         metadata['acquisition']['timestamp'] = acquisition_timestamp
 

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -235,9 +235,9 @@ def dicom_classify(zip_file_path, outbase, timezone):
         metadata['acquisition']['measurement'] = measurement_from_label.infer_measurement(dcm.get('SeriesDescription'))
     else:
         metadata['acquisition']['measurement'] = 'unknown'
-    # If no pixel data present, make measurement "Non-Image"
+    # If no pixel data present, make measurement "non-image"
     if not hasattr(dcm, 'PixelData'):
-        metadata['acquisition']['measurement'] = 'Non-Image'
+        metadata['acquisition']['measurement'] = 'non-image'
     if acquisition_timestamp:
         metadata['acquisition']['timestamp'] = acquisition_timestamp
 


### PR DESCRIPTION
Fixes #8 

After the measurement is inferred by the Series Description, if PixelData is not present in the DICOM file, the measurement value will be overwritten and assigned to be "Non-Image".