### PR TITLE
Match fieldmaps on the "fmap" substring

### DIFF
--- a/measurement-from-label.py
+++ b/measurement-from-label.py
@@ -161,6 +161,7 @@ def is_fieldmap(label):
         re.compile('(?=.*field)(?=.*map)', re.IGNORECASE),
         re.compile('(?=.*bias)(?=.*ch)', re.IGNORECASE),
         re.compile('field', re.IGNORECASE),
+        re.compile('fmap', re.IGNORECASE),
         re.compile('DISTORTION', re.IGNORECASE)
         ]
     return regex_search_label(regexes, label)

--- a/measurement-from-label.py
+++ b/measurement-from-label.py
@@ -162,6 +162,7 @@ def is_fieldmap(label):
         re.compile('(?=.*bias)(?=.*ch)', re.IGNORECASE),
         re.compile('field', re.IGNORECASE),
         re.compile('fmap', re.IGNORECASE),
+        re.compile('topup', re.IGNORECASE),
         re.compile('DISTORTION', re.IGNORECASE)
         ]
     return regex_search_label(regexes, label)


### PR DESCRIPTION
The BIDS recommendation is to label fieldmaps as `fmap_dir-LR` (for example)