### PR TITLE
Gear 909: dicom-mr-classifier 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get -y install \
 # Install scitran.data dependencies
 RUN pip install \
   "numpy>1.15.0,<1.16.0" \
-  "pydicom>2.0.0,<3.0.0" \
+  pydicom==2.1.2 \
   python-dateutil==2.6.0 \
   pytz==2017.2 \
   tzlocal==1.4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,22 +10,19 @@
 #        /data/outprefix
 #
 
-FROM ubuntu:trusty
+FROM python:3.7-buster
 
 MAINTAINER Michael Perry <lmperry@stanford.edu>
 
 # Install dependencies
 RUN apt-get update && apt-get -y install \
-    python \
-    python-dev \
-    python-pip \
     jq \
     wget
 
 # Install scitran.data dependencies
 RUN pip install \
-  numpy==1.15.1 \
-  pydicom==0.9.9 \
+  "numpy>1.15.0,<1.16.0" \
+  "pydicom>2.0.0,<3.0.0" \
   python-dateutil==2.6.0 \
   pytz==2017.2 \
   tzlocal==1.4 \

--- a/classification_from_label.py
+++ b/classification_from_label.py
@@ -368,7 +368,7 @@ def infer_classification(label):
         elif is_screenshot(label):
             classification['Intent'] = ['Screenshot']
         else:
-            print label.strip('\n') + ' --->>>> unknown'
+            print(label.strip('\n') + ' --->>>> unknown')
 
 
         # Add features to classification

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -500,6 +500,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
             weight = float(weight)
             metadata["session"]["weight"] = weight
         except:
+            log.warning('Could not parse PatientWeight, droppping.')
             pass
 
     # Subject Metadata
@@ -513,6 +514,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
                 age = int(age)
                 metadata["session"]["age"] = age
         except:
+            log.warning('Could not parse PatientAge, droppping.')
             pass
     if hasattr(dcm, "PatientName") and dcm.get("PatientName").given_name:
         # If the first name or last name field has a space-separated string, and one or the other field is not

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -539,7 +539,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
     # File classification
     dicom_file = {}
     dicom_file["name"] = os.path.basename(zip_file_path)
-    dicom_file["modality"] = format_string(dcm.get("Modality", "MR"))
+    dicom_file["modality"] = format_string(dcm.get("Modality", "MR") or "MR")
     dicom_file["classification"] = {}
 
     # Acquisition metadata

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -4,7 +4,7 @@ import os
 import re
 import json
 import pytz
-import dicom
+import pydicom
 import string
 import tzlocal
 import logging
@@ -225,12 +225,10 @@ def assign_type(s):
     Sets the type of a given input.
     """
     if (
-        type(s) == dicom.valuerep.PersonName
-        or type(s) == dicom.valuerep.PersonName3
-        or type(s) == dicom.valuerep.PersonNameBase
+        isinstance(s, pydicom.valuerep.PersonName)
     ):
         return format_string(s)
-    if type(s) == list or type(s) == dicom.multival.MultiValue:
+    if type(s) == list or type(s) == pydicom.multival.MultiValue:
         try:
             return [int(x) if type(x) == int else float(x) for x in s]
         except ValueError:
@@ -252,7 +250,7 @@ def format_string(in_string):
     formatted = re.sub(
         r"[^\x00-\x7f]", r"", str(in_string)
     )  # Remove non-ascii characters
-    formatted = filter(lambda x: x in string.printable, formatted)
+    formatted = "".join(filter(lambda x: x in string.printable, formatted))
     if len(formatted) == 1 and formatted == "?":
         formatted = None
     return formatted  # .encode('utf-8').strip()
@@ -263,10 +261,10 @@ def get_seq_data(sequence, ignore_keys):
     for seq in sequence:
         for s_key in seq.dir():
             s_val = getattr(seq, s_key, "")
-            if type(s_val) is dicom.uid.UID or s_key in ignore_keys:
+            if type(s_val) is pydicom.uid.UID or s_key in ignore_keys:
                 continue
 
-            if type(s_val) == dicom.sequence.Sequence:
+            if type(s_val) == pydicom.sequence.Sequence:
                 _seq = get_seq_data(s_val, ignore_keys)
                 seq_dict[s_key] = _seq
                 continue
@@ -298,7 +296,7 @@ def get_dicom_header(dcm):
     for tag in tags:
         try:
             if (tag not in exclude_tags) and (
-                type(dcm.get(tag)) != dicom.sequence.Sequence
+                type(dcm.get(tag)) != pydicom.sequence.Sequence
             ):
                 value = dcm.get(tag)
                 if value or value == 0:  # Some values are zero
@@ -312,7 +310,7 @@ def get_dicom_header(dcm):
                 else:
                     log.debug("No value found for tag: " + tag)
 
-            if type(dcm.get(tag)) == dicom.sequence.Sequence:
+            if type(dcm.get(tag)) == pydicom.sequence.Sequence:
                 seq_data = get_seq_data(dcm.get(tag), exclude_tags)
                 # Check that the sequence is not empty
                 if seq_data:
@@ -324,7 +322,7 @@ def get_dicom_header(dcm):
 
 
 def get_csa_header(dcm):
-    import dicom
+    import pydicom
     import nibabel.nicom.dicomwrappers
 
     exclude_tags = ["PhoenixZIP", "SrMsgBuffer"]
@@ -421,7 +419,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
     """
     Extracts metadata from dicom file header within a zip file and writes to .metadata.json.
     """
-    import dicom
+    import pydicom
 
     # Parse config for options
     if config:
@@ -453,7 +451,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
             if os.path.isfile(dcm_path):
                 try:
                     log.info("reading %s" % dcm_path)
-                    dcm = dicom.read_file(dcm_path, force=config_force)
+                    dcm = pydicom.dcmread(dcm_path, force=config_force)
                     # Here we check for the Raw Data Storage SOP Class, if there
                     # are other DICOM files in the zip then we read the next one,
                     # if this is the only class of DICOM in the file, we accept
@@ -474,7 +472,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
             "Not a zip. Attempting to read %s directly"
             % os.path.basename(zip_file_path)
         )
-        dcm = dicom.read_file(zip_file_path)
+        dcm = pydicom.dcmread(zip_file_path)
 
     if not dcm:
         log.warning(

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -545,7 +545,6 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
     # File classification
     dicom_file = {}
     dicom_file["name"] = os.path.basename(zip_file_path)
-    dicom_file["modality"] = format_string(dcm.get("Modality", "MR") or "MR")
     if dcm.get('Modality'):
         dicom_file["modality"] = format_string(dcm.get("Modality"))
     else:

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -505,7 +505,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
         try:
             age = parse_patient_age(dcm.get("PatientAge"))
             if age:
-                metadata["session"]["subject"]["age"] = int(age)
+                metadata["session"]["age"] = int(age)
         except:
             pass
     if hasattr(dcm, "PatientName") and dcm.get("PatientName").given_name:

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -540,6 +540,12 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
     dicom_file = {}
     dicom_file["name"] = os.path.basename(zip_file_path)
     dicom_file["modality"] = format_string(dcm.get("Modality", "MR") or "MR")
+    if dcm.get('Modality'):
+        pydicom_file["modality"] = format_string(dcm.get("Modality"))
+    else:
+        log.warning('No modality found.')
+        pydicom_file["modality"] = None
+
     dicom_file["classification"] = {}
 
     # Acquisition metadata

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -541,10 +541,10 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
     dicom_file["name"] = os.path.basename(zip_file_path)
     dicom_file["modality"] = format_string(dcm.get("Modality", "MR") or "MR")
     if dcm.get('Modality'):
-        pydicom_file["modality"] = format_string(dcm.get("Modality"))
+        dicom_file["modality"] = format_string(dcm.get("Modality"))
     else:
         log.warning('No modality found.')
-        pydicom_file["modality"] = None
+        dicom_file["modality"] = None
 
     dicom_file["classification"] = {}
 

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -495,7 +495,12 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
         metadata["session"]["label"] = session_label
 
     if hasattr(dcm, "PatientWeight") and dcm.get("PatientWeight"):
-        metadata["session"]["weight"] = assign_type(dcm.get("PatientWeight"))
+        weight = assign_type(dcm.get("PatientWeight"))
+        try:
+            weight = float(weight)
+            metadata["session"]["weight"] = weight
+        except:
+            pass
 
     # Subject Metadata
     metadata["session"]["subject"] = {}
@@ -505,7 +510,8 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
         try:
             age = parse_patient_age(dcm.get("PatientAge"))
             if age:
-                metadata["session"]["age"] = int(age)
+                age = int(age)
+                metadata["session"]["age"] = age
         except:
             pass
     if hasattr(dcm, "PatientName") and dcm.get("PatientName").given_name:

--- a/manifest.json
+++ b/manifest.json
@@ -8,10 +8,10 @@
   "source": "https://github.com/scitran-apps/dicom-mr-classifier/releases",
   "license": "Apache-2.0",
   "flywheel": "0",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "custom": {
     "gear-builder": {
-      "image": "scitran/dicom-mr-classifier:1.3.2",
+      "image": "scitran/dicom-mr-classifier:1.3.3",
       "category": "converter"
     },
     "flywheel": {

--- a/manifest.json
+++ b/manifest.json
@@ -8,10 +8,10 @@
   "source": "https://github.com/scitran-apps/dicom-mr-classifier/releases",
   "license": "Apache-2.0",
   "flywheel": "0",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "custom": {
     "gear-builder": {
-      "image": "scitran/dicom-mr-classifier:1.3.3",
+      "image": "scitran/dicom-mr-classifier:1.4.0",
       "category": "converter"
     },
     "flywheel": {


### PR DESCRIPTION
Various improvements:
* Move from python 2.7 -> python 3.7
* Bump pydicom version from 0.9.9 to 2.1.2
    * Add support for Enhanced MR Storage SOP Class
* Store age on session.age instead of session.subject.age
* Set Modality to `None` instead of an empty string when empty
* Drop and warn when PatientWeight and PatientAge are not float and int, respectively.