### PR TITLE
Hone infer_classification call criteria

### DIFF
--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -579,7 +579,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
         metadata["acquisition"]["label"] = series_desc
         classification = get_custom_classification(series_desc, config)
         log.info("Custom classification from config: %s", classification)
-        if (not classification) and ('MR' in dcm.get("Modality")):
+        if not classification and dcm.get("Modality") == "MR":
             classification = classification_from_label.infer_classification(series_desc)
             log.info("Inferred classification from label: %s", classification)
             # GEAR-1084, keep any custom classification already set.

--- a/dicom-mr-classifier.py
+++ b/dicom-mr-classifier.py
@@ -579,7 +579,7 @@ def dicom_classify(zip_file_path, outbase, timezone, config=None):
         metadata["acquisition"]["label"] = series_desc
         classification = get_custom_classification(series_desc, config)
         log.info("Custom classification from config: %s", classification)
-        if not classification:
+        if (not classification) and ('MR' in dcm.get("Modality")):
             classification = classification_from_label.infer_classification(series_desc)
             log.info("Inferred classification from label: %s", classification)
             # GEAR-1084, keep any custom classification already set.


### PR DESCRIPTION
Thought process: If a study is PET or CT, exclude the scan from further classification by infer_classification. 
- infer_classification looks like it applies subcategories to MR scans, not PET or CT.
- a user noted incorrect classification of a PET scan, b/c the feature "TOF" was in the series description. TOF in PET is an instrumentation note, not "time of flight" as in ASL.

Concern:
lines 561-565 indicate that `dcm.get("Modality")` might be empty (edge case). In that case, I think this proposed change would fail. I am uncertain what would be a more robust solution.